### PR TITLE
Fixing Windows support by changing logdir to POSIX format

### DIFF
--- a/streamlit_tensorboard/__init__.py
+++ b/streamlit_tensorboard/__init__.py
@@ -5,6 +5,7 @@ import shlex
 import random
 import html
 import json
+from pathlib import Path
 
 
 def st_tensorboard(logdir="/logs/", port=6006, width=None, height=800, scrolling=True):
@@ -30,7 +31,7 @@ def st_tensorboard(logdir="/logs/", port=6006, width=None, height=800, scrolling
     >>> st_tensorboard(logdir="/logs/", port=6006, width=1080)
     """
 
-    logdir = logdir
+    logdir = Path(str(logdir)).as_posix()
     port = port
     width = width
     height = height


### PR DESCRIPTION
Using `pathlib` to change the `logdir` path to POSIX format. The change would make the `shlex.split` work properly, thus making it work on Windows, and it will still work on Linux.